### PR TITLE
Update function-bind-polyfill.js

### DIFF
--- a/function-bind-polyfill.js
+++ b/function-bind-polyfill.js
@@ -28,7 +28,7 @@ if ( ! Function.prototype.bind) {
     
         };
         if(target.prototype) {
-            empty = function() { }
+            var empty = function() { }
             empty.prototype = target.prototype;
             bound.prototype = new empty();
         }


### PR DESCRIPTION
Fixes "TypeError: instanceof called on an object with an invalid prototype property."
When running in PhantomJS 1.9.x
