### PR TITLE
Fix for Karma-Cajon

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ var requireUsed = function(files) {
             if (typeof pattern === 'string' && pattern.indexOf('/karma-requirejs/') !== -1) {
                 return true;
             }
+             if (typeof pattern === 'string' && (pattern.indexOf("\\karma-cajon\\") !== -1 || pattern.indexOf("/karma-cajon/") !== -1)) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
`karma-chai-plugins` can't work with `cajon` by default. This PR fixes it.

Cajon is RequireJS that can load plain CommonJS modules w/o `define` wrap.