### PR TITLE
Modify sinon dep to ~1.14.1 [TEMPORARY]

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chai-as-promised": "^4.3.0",
     "chai-jquery": "^2.0.0",
     "chai-things": "^0.2.0",
-    "sinon": "^1.14.1",
+    "sinon": "~1.14.1",
     "sinon-chai": "^2.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses failure to load `sinon.js` due to https://github.com/princed/karma-chai-plugins/issues/24

The root cause is [a bug in the latest version of Sinon](https://github.com/cjohansen/Sinon.JS/issues/761) which unintentionally removed the `pkg` directory. The maintainers of Sinon are currently addressing the issue and say they will be fixing soon, but in the meantime libraries which consume Sinon are forced to hard-code their versions to the most recently working version — `1.14.1`. 

This is intended to be a __temporary__ fix until a permanent change is made
to Sinon lib and released.

cc @princed